### PR TITLE
make runs faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ VOLUME /report
 ENV FOCUS="(Networking).*(\[Conformance\])|\[Feature:NetworkPolicy\]"
 ADD kubeconfig /root/kubeconfig
 ADD ./bin/e2e.test .
-CMD ./e2e.test -kubeconfig=/root/kubeconfig --ginkgo.focus="$FOCUS" -report-dir=/report
-
+CMD ./e2e.test -kubeconfig=/root/kubeconfig --ginkgo.focus="$FOCUS" -report-dir=/report -test.parallel 16


### PR DESCRIPTION
by increasing default `-test.parallel 8` setting to 16. Took 300secs for me

```
Ran 11 of 693 Specs in 301.334 seconds
FAIL! -- 5 Passed | 6 Failed | 0 Pending | 682 Skipped --- FAIL: TestE2E (301.37s)
FAIL
time: 302
```